### PR TITLE
Use display inline-block to 1) Fix icon size on safari 2) Match 0.5

### DIFF
--- a/iron-icon.html
+++ b/iron-icon.html
@@ -63,15 +63,10 @@ See [iron-icons](http://www.polymer-project.org/components/iron-icons/demo.html)
 
   <style>
     :host {
-      display: inline-flex;
       position: relative;
-
+      display: inline-block;
       vertical-align: middle;
-      align-items: center;
-      justify-content: center;
-
       fill: currentcolor;
-
       width: 24px;
       height: 24px;
     }


### PR DESCRIPTION
Fixes #3 
