### PR TITLE
not all icons are square

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "iron-icon",
   "private": true,
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "An element that supports displaying an icon",
   "main": "iron-icon.html",
   "author": [

--- a/iron-icon.html
+++ b/iron-icon.html
@@ -64,8 +64,9 @@ See [iron-icons](http://www.polymer-project.org/components/iron-icons/demo.html)
 -->
 
 <style is="custom-style">
-  * {
-    --iron-icon-size: 24px;
+  :root {
+    --iron-icon-width: 24px;
+    --iron-icon-height: 24px;
   }
 </style>
 
@@ -81,8 +82,8 @@ See [iron-icons](http://www.polymer-project.org/components/iron-icons/demo.html)
 
       fill: currentcolor;
 
-      width: var(--iron-icon-size);
-      height: var(--iron-icon-size);
+      width: var(--iron-icon-width);
+      height: var(--iron-icon-height);
     }
   </style>
 


### PR DESCRIPTION
Split the `size` custom property into `width` and `height`
