### PR TITLE
Use custom property sizing

### DIFF
--- a/iron-icon.html
+++ b/iron-icon.html
@@ -24,10 +24,10 @@ Example setting size to 32px x 32px:
 
     <iron-icon class="big" src="big_star.png"></iron-icon>
 
-    <style>
+    <style is="custom-style">
       .big {
-        height: 32px;
-        width: 32px;
+        --iron-icon-height: 32px;
+        --iron-icon-width: 32px;
       }
     </style>
 


### PR DESCRIPTION
As noted in https://github.com/Polymer/polymer/issues/1720, the custom property shim doesn't currently support the old example, since `iron-icon` sets `height`/`width` using custom properties, which would override the user styles.
