### PR TITLE
Suppress compiler warnings about visibility

### DIFF
--- a/iron-icon.html
+++ b/iron-icon.html
@@ -149,6 +149,7 @@ Custom property | Description | Default
         return this.icon || !this.src;
       },
 
+      /** @suppress {visibility} */
       _updateIcon: function() {
         if (this._usesIconset()) {
           if (this._iconsetName) {


### PR DESCRIPTION
In Polymer convention, a behavior's _properties are protected, not private.
