### PR TITLE
set draggable false on img icon

### DIFF
--- a/iron-icon.html
+++ b/iron-icon.html
@@ -165,6 +165,7 @@ Custom property | Description | Default
             this._img = document.createElement('img');
             this._img.style.width = '100%';
             this._img.style.height = '100%';
+            this._img.draggable = false;
           }
           this._img.src = this.src;
           Polymer.dom(this.root).appendChild(this._img);


### PR DESCRIPTION
Primarily to fix
https://elements.polymer-project.org/elements/paper-icon-button?view=demo:demo/index.html

If you mousedown the octocat and mouseup outside of the octocat, the ink stays, and the more you repeat this the ink gets heavier.
Setting the image to not be draggable fixes this issue and makes image buttons work like the svg icons as far as dragging goes.
