### PR TITLE
docs(README.md) : fix "iron-icons" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Example of using an icon named `cherry` from a custom iconset with the ID `fruit
 See [iron-iconset](#iron-iconset) and [iron-iconset-svg](#iron-iconset-svg) for more information about
 how to create a custom iconset.
 
-See [iron-icons](http://www.polymer-project.org/components/iron-icons/demo.html) for the default set of icons.
+See [iron-icons](https://elements.polymer-project.org/elements/iron-icons?view=demo:demo/index.html) for the default set of icons.


### PR DESCRIPTION
Link is not working as polymer-project demo pages has been tranfered to elements.polymer-project.org.
Use the same link as https://elements.polymer-project.org/elements/iron-icon demo page
