### PR TITLE
Add type for _meta property

### DIFF
--- a/iron-icon.html
+++ b/iron-icon.html
@@ -129,11 +129,14 @@ Custom property | Description | Default
           type: String,
           observer: '_srcChanged'
         },
-        
+
+        /**
+         * @type {!Polymer.IronMeta}
+         */
         _meta: {
           value: Polymer.Base.create('iron-meta', {type: 'iconset'})
         }
-        
+
       },
 
       _DEFAULT_ICONSET: 'icons',
@@ -157,7 +160,8 @@ Custom property | Description | Default
       _updateIcon: function() {
         if (this._usesIconset()) {
           if (this._iconsetName) {
-            this._iconset = this._meta.byKey(this._iconsetName);
+            this._iconset = /** @type {?Polymer.Iconset} */ (
+              this._meta.byKey(this._iconsetName));
             if (this._iconset) {
               this._iconset.applyIcon(this, this._iconName, this.theme);
             } else {


### PR DESCRIPTION
Properties need types for compilation.

@jklein24 I tried making the type !IronMetaElement but I got `Unknown type IronMetaElement`. Did that ever work, or am I misremembering?
