### PR TITLE
Allow iconsets to be loaded asynchronously.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
+    "promise-polyfill": "polymerlabs/promise-polyfill#^1.0.0",
     "iron-iconset": "polymerelements/iron-iconset#^1.0.0",
     "iron-icons": "polymerelements/iron-icons#^1.0.0",
     "iron-component-page": "polymerelements/iron-component-page#^1.0.0",

--- a/demo/async.html
+++ b/demo/async.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+<head>
+  <title>iron-icon demo</title>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../iron-icon.html">
+  <link rel="import" href="../../paper-styles/demo-pages.html" >
+
+  <style is="custom-style">
+    #loading_message {
+      color: #444;
+      margin-bottom: 16px;
+    }
+    .vertical-section h4 {
+      border-left: 3px solid var(--paper-grey-300);
+      padding-left: 10px;
+    }
+
+    .vertical-section h4:hover {
+      border-left-color: var(--google-blue-700);
+    }
+  </style>
+</head>
+<body>
+  <div class="vertical-section-container centered">
+    <h4>
+      This demo is for an &lt;iron-icon&gt; with an asynchronously loaded
+      iconset.
+    </h4>
+
+    <div id='loading_message'>Waiting to load iconset...</div>
+
+    <div class="vertical-section">
+      <!-- iron-icon using a iron-iconset as its icon source -->
+      <iron-iconset name="example" icons="location" src="location.png" size="24" width="24"></iron-iconset>
+
+      <h4>&lt;iron-icon icon="example:location"&gt;</h4>
+      <iron-icon icon="example:location"></iron-icon>
+
+    </div>
+  </div>
+  <script>
+    setTimeout(function() {
+      // Import the code that powers the iron-iconset asynchronously
+      var linkElem = document.createElement('link');
+      linkElem.setAttribute('rel', 'import');
+      linkElem.setAttribute('href', '../../iron-iconset/iron-iconset.html');
+      document.head.appendChild(linkElem);
+      document.querySelector('#loading_message').innerText = "Iconset Loaded.";
+    }, 1000);
+  </script>
+</body>
+</html>

--- a/iron-icon.html
+++ b/iron-icon.html
@@ -164,9 +164,9 @@ Custom property | Description | Default
               this._meta.byKey(this._iconsetName));
             if (this._iconset) {
               this._iconset.applyIcon(this, this._iconName, this.theme);
+              this.unlisten(window, 'iron-iconset-added', '_updateIcon');
             } else {
-              this._warn(this._logf('_updateIcon', 'could not find iconset `'
-                + this._iconsetName + '`, did you import the iconset?'));
+              this.listen(window, 'iron-iconset-added', '_updateIcon');
             }
           }
         } else {

--- a/test/iron-icon.html
+++ b/test/iron-icon.html
@@ -22,6 +22,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../iron-icon.html">
   <link rel="import" href="../../iron-iconset/iron-iconset.html">
+  <link rel="import" href="../../promise-polyfill/promise-polyfill.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
 
 </head>
@@ -45,6 +46,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <iron-icon icon=""></iron-icon>
       <iron-icon></iron-icon>
       <iron-icon src=""></iron-icon>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="UsingAsyncIconset">
+    <template>
+      <iron-icon icon="async:location"></iron-icon>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="AsyncIconset">
+    <template>
+      <iron-iconset name="async" icons="location blank" src="location.png" size="24" width="48"></iron-iconset>
     </template>
   </test-fixture>
 
@@ -113,6 +126,23 @@ suite('<iron-icon>', function() {
       fixture('WithoutAnIconSource');
     });
   })
+
+  suite('when loading async', function() {
+    test('will get icon after iconset is added', function() {
+      var icon = fixture('UsingAsyncIconset');
+      expect(hasIcon(icon)).to.be.false;
+      return new Promise(function(resolve, reject) {
+        window.addEventListener('iron-iconset-added', function() {
+          if (hasIcon(icon)) {
+            resolve();
+          } else {
+            reject(new Error('icon didn\'t load after iconset loaded'));
+          }
+        });
+        fixture('AsyncIconset');
+      });
+    });
+  });
 });
   </script>
 


### PR DESCRIPTION
If an iron-icon can't find its iconset it will watch for new
iconsets to load until it finds the one it's looking for.

Fixes https://github.com/PolymerElements/iron-icons/issues/18

Depends on:
  https://github.com/PolymerElements/iron-iconset/pull/10
  https://github.com/PolymerElements/iron-iconset-svg/pull/25
