### PR TITLE
Ensures the <img> tag is removed from the DOM when switching from src to icon

### DIFF
--- a/iron-icon.html
+++ b/iron-icon.html
@@ -163,7 +163,14 @@ Custom property | Description | Default
       /** @suppress {visibility} */
       _updateIcon: function() {
         if (this._usesIconset()) {
-          if (this._iconsetName) {
+          if (this._img && this._img.parentNode) {
+            Polymer.dom(this.root).removeChild(this._img);
+          }
+          if (this._iconName === "") {
+            if (this._iconset) {
+              this._iconset.removeIcon(this);
+            }
+          } else if (this._iconsetName) {
             this._iconset = /** @type {?Polymer.Iconset} */ (
               this._meta.byKey(this._iconsetName));
             if (this._iconset) {
@@ -174,6 +181,9 @@ Custom property | Description | Default
             }
           }
         } else {
+          if (this._iconset) {
+            this._iconset.removeIcon(this);
+          }
           if (!this._img) {
             this._img = document.createElement('img');
             this._img.style.width = '100%';

--- a/test/iron-icon.html
+++ b/test/iron-icon.html
@@ -61,6 +61,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="SrcIconSwitch">
+    <template>
+      <iron-iconset name="example" icons="location blank" src="location.png" size="24" width="48"></iron-iconset>
+      <iron-icon></iron-icon>
+    </template>
+  </test-fixture>
+
   <script>
 function iconElementFor (node) {
   var nodes = Polymer.dom(node.root).childNodes;
@@ -141,6 +148,55 @@ suite('<iron-icon>', function() {
         });
         fixture('AsyncIconset');
       });
+    });
+  });
+
+  suite('when switching between src and icon properties', function() {
+    var icon;
+
+    setup(function() {
+      var elements = fixture('IconFromIconset');
+      icon = elements[1];
+    });
+
+    test('will display the icon if both icon and src are set', function() {
+      icon.src = '../demo/location.png';
+      icon.icon = 'example:location';
+      expect(hasIcon(icon)).to.be.true;
+      expect(iconElementFor(icon)).to.not.exist;
+
+      // Check if it works too it we change the affectation order
+      icon.icon = 'example:location';
+      icon.src = '../demo/location.png';
+      expect(hasIcon(icon)).to.be.true;
+      expect(iconElementFor(icon)).to.not.exist;
+    });
+
+    test('will display the icon when src is defined first and then reset', function() {
+      icon.src = '../demo/location.png';
+      icon.icon = null;
+      icon.src = null;
+      icon.icon = 'example:location';
+      expect(hasIcon(icon)).to.be.true;
+      expect(iconElementFor(icon)).to.not.exist;
+    });
+
+    test('will display the src when icon is defined first and then reset', function() {
+      icon.src = null;
+      icon.icon = 'example:location';
+      icon.src = '../demo/location.png';
+      icon.icon = null;
+      expect(hasIcon(icon)).to.be.false;
+      expect(iconElementFor(icon)).to.exist;
+    });
+
+    test('will display nothing if both properties are unset', function() {
+      icon.src = '../demo/location.png';
+      icon.icon = 'example:location';
+      icon.src = null;
+      icon.icon = null;
+      expect(hasIcon(icon)).to.be.false;
+      expect(iconElementFor(icon)).to.not.exist;
     });
   });
 });


### PR DESCRIPTION
When you set the image to display with the `src`attribute first and then you set
`src = null` and `icon = "check"` the previous image is still displayed

This is due to the fact that the <img> tag isn't removed from the DOM.

This PR fixes this issue
