### PR TITLE
Reflect icon property to attribute

### DIFF
--- a/iron-icon.html
+++ b/iron-icon.html
@@ -119,7 +119,8 @@ Custom property | Description | Default
          * `iconset_name:icon_name`.
          */
         icon: {
-          type: String
+          type: String,
+          reflectToAttribute: true
         },
 
         /**


### PR DESCRIPTION
It's nice to style `iron-icon`s based on which icon they show:

```
iron-icon[icon='done'] {
  --iron-icon-fill-color: var(--google-green-500);
}
```

However, if the `icon` property is changed dynamically, the new style rules won't apply (even after `updateStyles`) because the attribute hasn't changed.
