### PR TITLE
Fixes #8 Added an alt property to iron-icon

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -36,12 +36,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <!-- iron-icon using a iron-iconset as its icon source -->
       <iron-iconset name="example" icons="location" src="location.png" size="24" width="24"></iron-iconset>
 
-      <h4>&lt;iron-icon icon="example:location"&gt;</h4>
-      <iron-icon icon="example:location"></iron-icon>
+      <h4>&lt;iron-icon icon="example:location" alt="An iconset alternate text"&gt;</h4>
+      <iron-icon icon="example:location" alt="An iconset alternate text"></iron-icon>
 
       <!-- iron-icon using an image url as its icon source -->
-      <h4>&lt;iron-icon src="location.png"&gt;</h4>
-      <iron-icon src="location.png"></iron-icon>
+      <h4>&lt;iron-icon src="location.png" alt="A trivial icon alternate text"&gt;</h4>
+      <iron-icon src="location.png" alt="A trivial icon alternate text"></iron-icon>
+
     </div>
   </div>
 </body>

--- a/iron-icon.html
+++ b/iron-icon.html
@@ -142,8 +142,15 @@ Custom property | Description | Default
         _meta: {
           value: Polymer.Base.create('iron-meta', {type: 'iconset'}),
           observer: '_updateIcon'
-        }
+        },
 
+        /**
+         * Specifies the alternate text for the icon, for accessibility.
+         */
+        alt: {
+          type: String,
+          observer: "_altChanged"
+        }
       },
 
       _DEFAULT_ICONSET: 'icons',
@@ -157,6 +164,30 @@ Custom property | Description | Default
 
       _srcChanged: function(src) {
         this._updateIcon();
+      },
+
+      _altChanged: function(newValue, oldValue) {
+        var label = this.getAttribute('aria-label');
+        // Don't stomp over a user-set aria-label.
+        if (!label || oldValue == label) {
+          this.setAttribute('aria-label', newValue);
+        }
+
+        this._updateImgAltText(newValue);
+      },
+
+      _hasValidAltText: function (altText) {
+        return ((altText !== null) && (altText !== undefined));
+      },
+
+      _updateImgAltText: function (altText) {
+        if (this._img) {
+          if (this._hasValidAltText(altText)) {
+            this._img.setAttribute('alt', altText);
+          } else {
+            this._img.removeAttribute('alt');
+          }
+        }
       },
 
       _usesIconset: function() {
@@ -192,6 +223,7 @@ Custom property | Description | Default
             this._img.style.width = '100%';
             this._img.style.height = '100%';
             this._img.draggable = false;
+            this._updateImgAltText(this.alt);
           }
           this._img.src = this.src;
           Polymer.dom(this.root).appendChild(this._img);

--- a/test/iron-icon.html
+++ b/test/iron-icon.html
@@ -213,6 +213,56 @@ suite('<iron-icon>', function() {
       var holder = fixture('ParentForceUpdate');
     });
   });
+
+  suite('accessibility', function() {
+    suite('accessibility tests for an Trivial Icon', function() {
+      var icon;
+
+      setup(function() {
+        icon = fixture('TrivialIcon');
+      });
+
+      test('img has no alt text by default', function() {
+        var img = iconElementFor(icon);
+        assert.isFalse(img.hasAttribute('alt'));
+      });
+      test('img alt text is empty string when iron-icon alt text is empty string', function() {
+        var img = iconElementFor(icon);
+        icon.alt = '';
+        assert.isTrue(img.hasAttribute('alt'));
+        assert.strictEqual(img.getAttribute('alt'), '');
+      });
+      test('img alt text matches iron-icon alt text when defined', function() {
+        var img = iconElementFor(icon);
+        icon.alt = 'alt text value';
+        assert.isTrue(img.hasAttribute('alt'));
+        assert.strictEqual(img.getAttribute('alt'), 'alt text value');
+      });
+    });
+
+    suite('accessibility tests for an Icon From Icon Set', function() {
+      var icon;
+
+      setup(function() {
+        var elements = fixture('IconFromIconset');
+        icon = elements[1];
+      });
+
+      test('icon has no aria-label text by default', function() {
+        assert.isFalse(icon.hasAttribute('aria-label'));
+      });
+      test('icon aria-label text is empty string when iron-icon alt text is empty string', function() {
+        icon.alt = '';
+        assert.isTrue(icon.hasAttribute('aria-label'));
+        assert.strictEqual(icon.getAttribute('aria-label'), '');
+      });
+      test('icon aria-label text matches iron-icon alt text when defined', function() {
+        icon.alt = 'alt text value';
+        assert.isTrue(icon.hasAttribute('aria-label'));
+        assert.strictEqual(icon.getAttribute('aria-label'), 'alt text value');
+      });
+    });
+  });
 });
   </script>
 


### PR DESCRIPTION
Fixes #8 Added an alt property to iron-icon that reflects on img alternate text and iron-icon aria-label.
