### PR TITLE
<img> element should inherit border-radius from its parent. Fix #90

### DIFF
--- a/iron-icon.html
+++ b/iron-icon.html
@@ -196,6 +196,7 @@ Custom property | Description | Default
             this._img = document.createElement('img');
             this._img.style.width = '100%';
             this._img.style.height = '100%';
+            this._img.style.borderRadius = 'inherit';
             this._img.draggable = false;
           }
           this._img.src = this.src;


### PR DESCRIPTION
I don't know if you want to add a specific mixin for the `img` element, but I think in the meantime you could apply this little patch to let fix #90.

If the `img` element inherit border-radius from its parent there's no need for a new mixin and it works with both shady and shadow dom.

For example:
      `iron-icon {
        --iron-icon: {
          border-radius: 50%;
        };
      }`