### PR TITLE
Fix isAttached usage in observers

### DIFF
--- a/iron-icon.html
+++ b/iron-icon.html
@@ -145,22 +145,21 @@ Custom property | Description | Default
       },
 
       observers: [
-        '_updateIcon(_meta, isAttached)',
-        '_updateIcon(theme, isAttached)',
+        '_updateIcon(_meta, theme, isAttached)',
         '_srcChanged(src, isAttached)',
         '_iconChanged(icon, isAttached)'
       ],
 
       _DEFAULT_ICONSET: 'icons',
 
-      _iconChanged: function(icon) {
+      _iconChanged: function(icon, isAttached) {
         var parts = (icon || '').split(':');
         this._iconName = parts.pop();
         this._iconsetName = parts.pop() || this._DEFAULT_ICONSET;
         this._updateIcon();
       },
 
-      _srcChanged: function(src) {
+      _srcChanged: function(src, isAttached) {
         this._updateIcon();
       },
 
@@ -169,7 +168,7 @@ Custom property | Description | Default
       },
 
       /** @suppress {visibility} */
-      _updateIcon: function() {
+      _updateIcon: function(meta, theme, isAttached) {
         if (this._usesIconset()) {
           if (this._img && this._img.parentNode) {
             Polymer.dom(this.root).removeChild(this._img);


### PR DESCRIPTION
There's a lot of failing builds because of this package.

Example: https://travis-ci.org/PolymerElements/paper-dropdown-menu/builds/188272638

```sh
$ polylint
../iron-icon/iron-icon.html:105:3
    Property isAttached not found in 'properties' for element 'iron-icon'
../iron-icon/iron-icon.html:105:3
    Property isAttached not found in 'properties' for element 'iron-icon'
../iron-icon/iron-icon.html:105:3
    Property isAttached not found in 'properties' for element 'iron-icon'
../iron-icon/iron-icon.html:105:3
    Property isAttached not found in 'properties' for element 'iron-icon'
```

This PR is aimed to fix those errors.