### PR TITLE
Fix broken link in demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -26,7 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <h3>
       This demo is for a single &lt;iron-icon&gt;. If you're looking for the
       whole set of available icons, check out the
-      <a href="/element/PolymerElements/iron-icons/demo/demo/index.html">&lt;iron-icons&gt;
+      <a href="https://www.webcomponents.org/element/PolymerElements/iron-icons/demo/demo/index.html" target="_top">&lt;iron-icons&gt;
       demo.</a>
     </h3>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -26,7 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <h3>
       This demo is for a single &lt;iron-icon&gt;. If you're looking for the
       whole set of available icons, check out the
-      <a href="/element/PolymerElements/iron-icons/demo/demo/index.html">&lt;iron-icons&gt;
+      <a href="/PolymerElements/iron-icons/v2.0.0/iron-icons/demo/index.html">&lt;iron-icons&gt;
       demo.</a>
     </h3>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -26,7 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <h3>
       This demo is for a single &lt;iron-icon&gt;. If you're looking for the
       whole set of available icons, check out the
-      <a href="/PolymerElements/iron-icons/v2.0.0/iron-icons/demo/index.html">&lt;iron-icons&gt;
+      <a href="/element/PolymerElements/iron-icons/demo/demo/index.html">&lt;iron-icons&gt;
       demo.</a>
     </h3>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -26,8 +26,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <h3>
       This demo is for a single &lt;iron-icon&gt;. If you're looking for the
       whole set of available icons, check out the
-      <!-- TODO(bicknellr): Update this link. -->
-      <a href="/elements/iron-icons?view=demo:demo/index.html">&lt;iron-icons&gt;
+      <a href="/element/PolymerElements/iron-icons/demo/demo/index.html">&lt;iron-icons&gt;
       demo.</a>
     </h3>
 


### PR DESCRIPTION
I encountered this broken link (and TODO) on the iron-icon webcomponents.org page. (https://www.webcomponents.org/element/PolymerElements/iron-icon/elements/iron-icon) 