### PR TITLE
Fix: iron-meta not being created in chrome 60

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,26 @@
 language: node_js
-sudo: required
-before_script:
-  - npm install -g polymer-cli
-  - polymer install --variants
+sudo: false
+dist: trusty
+node_js: stable
+cache:
+  directories:
+    - node_modules
 env:
   global:
     - secure: >-
         TTp7q3OKEpaFqnqbYczhMd8iXTa1Ya0jOQVq1OhljpJogLWb78qvHLHgnxgMWkw+/KDyE5KHW1CXhYUQa7C9QF2Zn7uoN27+7+4q7HuK3pTuUtqdfstLVuLHQrfK6VqUT4XjSpeMzNX/HxuD3EMBH0bMBR4CIr76sLJOuIL/XF8=
     - secure: >-
         damHvQXygRYIJG/8Vmqh7U4zxoi5224JIZiZVQL6I5z//s5zqHq6AqwDyfOoc0zWndJCwE8NvOzKD/lmVYXIsPcY95kkZS45Dbye0krYWUzKnv42rDi/7olXcg647iAEDVhW3BRHmA+opzQtKUpAkXl97DtPVkszLL1ReyNyv3A=
-node_js: stable
 addons:
   firefox: latest
-  apt:
-    sources:
-      - google-chrome
-    packages:
-      - google-chrome-stable
+  chrome: stable
+install:
+  - npm install -g polymer-cli
+  - polymer install --variants
+before_script:
+  - polymer lint --rules polymer-2-hybrid --input *.html
 script:
   - xvfb-run polymer test
   - >-
     if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then polymer test -s 'default';
     fi
-dist: trusty

--- a/iron-icon.html
+++ b/iron-icon.html
@@ -104,6 +104,8 @@ Custom property | Description | Default
         display: none;
       }
     </style>
+
+    <iron-meta id="meta" type="iconset"></iron-meta>
   </template>
 
   <script>
@@ -142,9 +144,7 @@ Custom property | Description | Default
         /**
          * @type {!Polymer.IronMeta}
          */
-        _meta: {
-          value: Polymer.Base.create('iron-meta', {type: 'iconset'})
-        }
+        _meta: Object
 
       },
 
@@ -154,6 +154,11 @@ Custom property | Description | Default
         '_srcChanged(src, isAttached)',
         '_iconChanged(icon, isAttached)'
       ],
+
+      ready() {
+        // Used to get around an issue with chrome 60
+        this._meta = this.$.meta;
+      },
 
       _DEFAULT_ICONSET: 'icons',
 


### PR DESCRIPTION
Turns out that _meta is not getting created with the definition for iron-meta in chrome 60.

This *might* address #105 as well.

@stramel will follow up with an update to travis to get it running in chrome 60.