### PR TITLE
Automatic format!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
     update-types".' && false)
   - >-
     npm run format && git diff --exit-code || (echo -e '\n\033[31mERROR:\033[0m
-    Typings are stale. Please run "npm run format".' && false)
+    Project is not formatted. Please run "npm run format".' && false)
 env:
   global:
     - secure: >-

--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
       "integrity": "sha512-h3wnflb+jMTipvbbZnClgA2BexrT4w0GcfoCz5qyxd0IRsbqhLSyesM6mqZTAnhbVmhyTm5tuxfRu9R+8l+lGw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.3"
+        "@types/node": "8.10.7"
       }
     },
     "@types/glob": {
@@ -128,7 +128,7 @@
       "requires": {
         "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.6.3"
+        "@types/node": "8.10.7"
       }
     },
     "@types/is-windows": {
@@ -144,9 +144,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.3.tgz",
-      "integrity": "sha512-igaEysRgtg5tYJVIdQ1T2lJ3G6OmoY7g0YVWKHLFiVs4YUChd9IRSiLoHSLffwut+CpsHHBDj4vRxxNEMstctw==",
+      "version": "8.10.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.7.tgz",
+      "integrity": "sha512-5QC0YAHH7aXzrrbgQ+faSeBKbJwTaUyYuaywYzDTr1Myz5C0knx5FHOV5QyhBeE1x8n2xfkBUGE/C0X1paLp+Q==",
       "dev": true
     },
     "@types/parse5": {
@@ -155,7 +155,7 @@
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.3"
+        "@types/node": "8.10.7"
       }
     },
     "@types/resolve": {
@@ -164,7 +164,7 @@
       "integrity": "sha512-g+Rg8uMWY76oYTyaL+m7ZcblqF/oj7pE6uEUyACluJx4zcop1Lk14qQiocdEkEVMDFm6DmKpxJhsER+ZuTwG3g==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.3"
+        "@types/node": "8.10.7"
       }
     },
     "@types/winston": {
@@ -173,7 +173,7 @@
       "integrity": "sha512-zzruYOEtNgfS3SBjcij1F6HlH6My5n8WrBNhP3fzaRM22ba70QBC2ATs18jGr88Fy43c0z8vFJv5wJankfxv2A==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.3"
+        "@types/node": "8.10.7"
       }
     },
     "ansi-regex": {


### PR DESCRIPTION
Runs the experimental autoformatter [webmat](https://github.com/PolymerLabs/webmat) which runs clang-format on js files and makes it so that it can run on HTML files. Please look through this PR with `?w=1` in the diff to make sure that no logic was changed.

What has changed?
You can run the formatter on the whole project by running `npm run format` and ex/include files from the formatter, and enter your custom clang-format config in a formatconfig.json see webmat readme for more!