### PR TITLE
Use the non-element API for iron-meta

### DIFF
--- a/iron-icon.js
+++ b/iron-icon.js
@@ -16,6 +16,8 @@ import {dom} from '@polymer/polymer/lib/legacy/polymer.dom.js';
 import {html} from '@polymer/polymer/lib/utils/html-tag.js';
 import {Base} from '@polymer/polymer/polymer-legacy.js';
 
+const meta = new IronMeta({type: 'iconset'});
+
 /**
 
 The `iron-icon` element displays an icon. By default an icon renders as a 24px
@@ -132,15 +134,10 @@ Polymer({
      */
     src: {type: String},
 
-    /**
-     * @type {!IronMeta}
-     */
-    _meta: {value: Base.create('iron-meta', {type: 'iconset'})}
-
   },
 
   observers: [
-    '_updateIcon(_meta, isAttached)',
+    '_updateIcon(isAttached)',
     '_updateIcon(theme, isAttached)',
     '_srcChanged(src, isAttached)',
     '_iconChanged(icon, isAttached)'
@@ -173,9 +170,9 @@ Polymer({
         if (this._iconset) {
           this._iconset.removeIcon(this);
         }
-      } else if (this._iconsetName && this._meta) {
-        this._iconset = /** @type {?Polymer.Iconset} */ (
-            this._meta.byKey(this._iconsetName));
+      } else if (this._iconsetName) {
+        this._iconset =
+            /** @type {?Polymer.Iconset} */ (meta.byKey(this._iconsetName));
         if (this._iconset) {
           this._iconset.applyIcon(this, this._iconName, this.theme);
           this.unlisten(window, 'iron-iconset-added', '_updateIcon');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@polymer/iron-icon",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "generate-types": "gen-typescript-declarations --deleteExisting --outDir . --verify",
     "prepare": "npm run generate-types"
   },
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "iron-icon.js",
   "author": "The Polymer Authors",
   "dependencies": {


### PR DESCRIPTION
The element API is just a wrapper around the non-element API.
This is cleaner, simpler, and fixes an odd bug in FireFox where the
iron-icon has been upgraded but its _meta property has not been.

Downstreamed as cl/232029631